### PR TITLE
bugfix(work-list): Swap website icons to prevent GitHub link glitch

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,13 +214,13 @@
               <aside data-work="work-front">
                 <h6>SuitAndCape</h6>
                 <p>This very website.  Built using JavaScript, CSS3, HTML5, jQuery, Sass, RAPTORFrame, Gulp, and occasionally other technologies I'm trying out.</p>
-                <a href="http://SuitAndCape.github.io/" class="icon-link" target="_blank" aria-label="SuitAndCape website"></a>
                 <a href="https://github.com/SuitAndCape/SuitAndCape.github.io" class="icon-social-github" target="_blank" aria-label="SuitAndCape GitHub repo"></a>
+                <a href="http://SuitAndCape.github.io/" class="icon-link" target="_blank" aria-label="SuitAndCape website"></a>
               </aside>
               <aside data-work="work-back">
                 <h6>SuitAndCape</h6>
-                <a href="http://SuitAndCape.github.io/" class="icon-link" target="_blank" aria-label="SuitAndCape website"></a>
                 <a href="https://github.com/SuitAndCape/SuitAndCape.github.io" class="icon-social-github" target="_blank" aria-label="SuitAndCape GitHub repo"></a>
+                <a href="http://SuitAndCape.github.io/" class="icon-link" target="_blank" aria-label="SuitAndCape website"></a>
               </aside>
             </div>
           </li>
@@ -229,13 +229,13 @@
               <aside data-work="work-front">
                 <h6>e-dapp</h6>
                 <p>The minimalistic portfolio of Eric Lawrence Dapp, where beautiful music and thoughtful blog posts about data analysis live together in harmony.</p>
-                <a href="http://e-dapp.github.io/" class="icon-link" target="_blank" aria-label="e-dapp website"></a>
                 <a href="https://github.com/e-dapp/e-dapp.github.io" class="icon-social-github" target="_blank" aria-label="e-dapp GitHub repo"></a>
+                <a href="http://e-dapp.github.io/" class="icon-link" target="_blank" aria-label="e-dapp website"></a>
               </aside>
               <aside data-work="work-back">
                 <h6>e-dapp</h6>
-                <a href="http://e-dapp.github.io/" class="icon-link" target="_blank" aria-label="e-dapp website"></a>
                 <a href="https://github.com/e-dapp/e-dapp.github.io" class="icon-social-github" target="_blank" aria-label="e-dapp GitHub repo"></a>
+                <a href="http://e-dapp.github.io/" class="icon-link" target="_blank" aria-label="e-dapp website"></a>
               </aside>
             </div>
           </li>

--- a/source/root/index.html
+++ b/source/root/index.html
@@ -214,13 +214,13 @@
               <aside data-work="work-front">
                 <h6>SuitAndCape</h6>
                 <p>This very website.  Built using JavaScript, CSS3, HTML5, jQuery, Sass, RAPTORFrame, Gulp, and occasionally other technologies I'm trying out.</p>
-                <a href="http://SuitAndCape.github.io/" class="icon-link" target="_blank" aria-label="SuitAndCape website"></a>
                 <a href="https://github.com/SuitAndCape/SuitAndCape.github.io" class="icon-social-github" target="_blank" aria-label="SuitAndCape GitHub repo"></a>
+                <a href="http://SuitAndCape.github.io/" class="icon-link" target="_blank" aria-label="SuitAndCape website"></a>
               </aside>
               <aside data-work="work-back">
                 <h6>SuitAndCape</h6>
-                <a href="http://SuitAndCape.github.io/" class="icon-link" target="_blank" aria-label="SuitAndCape website"></a>
                 <a href="https://github.com/SuitAndCape/SuitAndCape.github.io" class="icon-social-github" target="_blank" aria-label="SuitAndCape GitHub repo"></a>
+                <a href="http://SuitAndCape.github.io/" class="icon-link" target="_blank" aria-label="SuitAndCape website"></a>
               </aside>
             </div>
           </li>
@@ -229,13 +229,13 @@
               <aside data-work="work-front">
                 <h6>e-dapp</h6>
                 <p>The minimalistic portfolio of Eric Lawrence Dapp, where beautiful music and thoughtful blog posts about data analysis live together in harmony.</p>
-                <a href="http://e-dapp.github.io/" class="icon-link" target="_blank" aria-label="e-dapp website"></a>
                 <a href="https://github.com/e-dapp/e-dapp.github.io" class="icon-social-github" target="_blank" aria-label="e-dapp GitHub repo"></a>
+                <a href="http://e-dapp.github.io/" class="icon-link" target="_blank" aria-label="e-dapp website"></a>
               </aside>
               <aside data-work="work-back">
                 <h6>e-dapp</h6>
-                <a href="http://e-dapp.github.io/" class="icon-link" target="_blank" aria-label="e-dapp website"></a>
                 <a href="https://github.com/e-dapp/e-dapp.github.io" class="icon-social-github" target="_blank" aria-label="e-dapp GitHub repo"></a>
+                <a href="http://e-dapp.github.io/" class="icon-link" target="_blank" aria-label="e-dapp website"></a>
               </aside>
             </div>
           </li>


### PR DESCRIPTION
- github.io sites were only appearing as repo links if they were followed by the actual repo link
  - Solution: put github.io links after repo links
